### PR TITLE
Removed dependency on #blank? for type_caster.rb

### DIFF
--- a/lib/core_ext/string.rb
+++ b/lib/core_ext/string.rb
@@ -4,5 +4,9 @@ module ActiveSupportMethods
       $1.upcase
     end
   end
+
+  def blank?
+    empty?
+  end
 end
 String.send :include, ActiveSupportMethods unless String.new.respond_to?(:underscore)

--- a/lib/couch_potato/persistence/type_caster.rb
+++ b/lib/couch_potato/persistence/type_caster.rb
@@ -3,15 +3,15 @@ module CouchPotato
     class TypeCaster #:nodoc:
       def cast(value, type)
         if type == :boolean
-          cast_boolen(value)
+          cast_boolean(value)
         else
           cast_native(value, type)
         end
       end
-      
+
       private
-      
-      def cast_boolen(value)
+
+      def cast_boolean(value)
         if [FalseClass, TrueClass].include?(value.class) || value.nil?
           value
         elsif [0, '0'].include?(value)
@@ -20,7 +20,7 @@ module CouchPotato
           true
         end
       end
-      
+
       def cast_native(value, type)
         if type && !value.instance_of?(type)
           if type == Fixnum
@@ -34,7 +34,7 @@ module CouchPotato
           value
         end
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
I've simply replaced calls blank? with the same logic used by ActiveSupport's #blank?. The same tests remain passing in Linux (Ubuntu 10.04 64-bit), as remain failing three tests for Time.

Reported in http://github.com/langalex/couch_potato/issues#issue/25.
