### PR TITLE
Support yielding to blocks on #initialize

### DIFF
--- a/lib/couch_potato/persistence.rb
+++ b/lib/couch_potato/persistence.rb
@@ -30,7 +30,8 @@ module CouchPotato
     end
 
     # initialize a new instance of the model optionally passing it a hash of attributes.
-    # the attributes have to be declared using the #property method
+    # the attributes have to be declared using the #property method.
+    # the new model will be yielded to an optionally given block.
     # 
     # example: 
     #   class Book
@@ -38,11 +39,18 @@ module CouchPotato
     #     property :title
     #   end
     #   book = Book.new :title => 'Time to Relax'
+    #
+    #   OR
+    #
+    #   book = Book.new do |b|
+    #     b.title = 'Time to Relax'
+    #   end
     #   book.title # => 'Time to Relax'
     def initialize(attributes = {})
       attributes.each do |name, value|
         self.send("#{name}=", value)
       end if attributes
+      yield self if block_given?
     end
     
     # assign multiple attributes at once.

--- a/spec/unit/initialize_spec.rb
+++ b/spec/unit/initialize_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+class Document
+  include CouchPotato::Persistence
+  
+  property :title
+  property :content
+end
+
+describe "new" do
+  context "without arguments" do
+    subject { Document.new }
+
+    it { should be_a(Document) }
+    its(:title) { should be_nil }
+    its(:content) { should be_nil }
+  end
+
+  context "with an argument hash" do
+    subject { Document.new(:title => 'My Title') }
+
+    it { should be_a(Document) }
+    its(:title) { should == 'My Title'}
+    its(:content) { should be_nil }
+  end
+
+  context "yielding to a block" do
+    subject {
+      Document.new(:title => 'My Title') do |doc|
+        doc.content = 'My Content'
+      end
+    }
+
+    it { should be_a(Document) }
+    its(:title) { should == 'My Title'}
+    its(:content) { should == 'My Content'}
+  end
+end


### PR DESCRIPTION
Hi Alex,

was hältst Du davon, CouchDB-Modelle auch per Block initialisieren zu können (auch gemischt mit einem Attribute-Hash):

```
Document.new(:title => 'My Title') do |doc|
  doc.content = 'My Content'
end
```

Ist mir neulich aufgefallen, dass dies noch nicht geht -- ich benutze sowas gern bei AR Modellen im Zusammenhand mit protected_attrs.

Cheers,
Martin
