### PR TITLE
allow custom emit values for model views

### DIFF
--- a/lib/couch_potato/view/model_view_spec.rb
+++ b/lib/couch_potato/view/model_view_spec.rb
@@ -25,14 +25,15 @@ module CouchPotato
         end
       end
 
-      # Allow custom emit values
+      # Allow custom emit values. Raise when the specified argument is not recognized
       def emit_value
         case options[:emit_value]
         when Symbol then "doc['#{options[:emit_value]}']"
         when String then options[:emit_value]
         when Numeric then options[:emit_value]
+        when NilClass then 1
         else
-          1
+          raise "The emit value specified is not recognized"
         end
       end
       

--- a/spec/unit/model_view_spec_spec.rb
+++ b/spec/unit/model_view_spec_spec.rb
@@ -16,7 +16,7 @@ describe CouchPotato::View::ModelViewSpec, 'map_function' do
     spec.map_function.should include(%{emit(doc[''], doc['count'])})
   end
 
-  it "should have a custom emit value when specified as symbol" do
+  it "should have a custom emit value when specified as string" do
     spec = CouchPotato::View::ModelViewSpec.new Object, 'all', {:emit_value => "doc['a'] + doc['b']"}, {}
     spec.map_function.should include("emit(doc[''], doc['a'] + doc['b'])")
   end
@@ -36,8 +36,8 @@ describe CouchPotato::View::ModelViewSpec, 'map_function' do
     spec.map_function.should include("emit(doc[''], 1")
   end
 
-  it "should have a emit value of 1 when something else is specified" do
+  it "should raise exception when emit value cannot be handled" do
     spec = CouchPotato::View::ModelViewSpec.new Object, 'all', {:emit_value => []}, {}
-    spec.map_function.should include("emit(doc[''], 1")
+    lambda { spec.map_function }.should raise_error
   end
 end


### PR DESCRIPTION
This will allow easy setting of custom emit values in stead of just 1. Example:

``` ruby
class ICountForTwo
  view :for_method, :emit_value => :count
  view :with_value, :emit_value => 2
  def count
    2
  end
end
```

Specs run with:
Gems included by the bundle:
- activemodel (3.0.9)
- activesupport (3.0.9)
- builder (2.1.2)
- bundler (1.0.15)
- couch_potato (0.5.7 8a5724e)
- couchrest (1.1.2)
- diff-lcs (1.1.2)
- i18n (0.5.0)
- json (1.5.3)
- mime-types (1.16)
- multi_json (1.0.3)
- rake (0.9.2)
- rest-client (1.6.3)
- rspec (2.6.0)
- rspec-core (2.6.4)
- rspec-expectations (2.6.0)
- rspec-mocks (2.6.0)
- timecop (0.3.5)
- tzinfo (0.3.29)
