### PR TITLE
Fix error no such file to load — json/add/rails

### DIFF
--- a/couch_potato.gemspec
+++ b/couch_potato.gemspec
@@ -11,16 +11,16 @@ Gem::Specification.new do |s|
   s.authors = ["Alexander Lang"]
   s.version     = CouchPotato::VERSION
   s.platform    = Gem::Platform::RUBY
-  
-  s.add_dependency 'json'
+
+  s.add_dependency 'json', '~> 1.6.0'
   s.add_dependency 'couchrest', '>=1.0.1'
   s.add_dependency 'activemodel'
-  
+
   s.add_development_dependency 'rspec', '>=2.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'tzinfo'
   s.add_development_dependency 'rake'
-  
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/lib/couch_potato.rb
+++ b/lib/couch_potato.rb
@@ -1,7 +1,6 @@
 require 'couchrest'
 require 'json'
 require 'json/add/core'
-require 'json/add/rails' rescue nil
 
 require 'ostruct'
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/7442788/couch-potato-no-such-file-to-load-json-add-rails/7444162#7444162

There are two solutions to this issue:
1. bump JSON requirement in .gemspec to `~> 1.6.0` and remove the require statement
2. silent the require statement in case of error

I chose the latter because forcing the use of `~> 1.6.0` might break gem compatibility with very old versions of ActiveSupport and make this library not usable with Rails < 3.0. Of course, this is just a guess.

If you bump the release number to `0.6.0` you might want to ignore compatibility with old ActiveSupport versions and jump to JSON 1.6.0 (+1 for this solution).
