### PR TITLE
Make therubyracer a runtime dependency to fix load errors (v8)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,14 +5,15 @@ PATH
       activemodel
       couchrest (>= 1.0.1)
       json (~> 1.6.0)
+      therubyracer
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.1)
-      activesupport (= 3.2.1)
+    activemodel (3.2.3)
+      activesupport (= 3.2.3)
       builder (~> 3.0.0)
-    activesupport (3.2.1)
+    activesupport (3.2.3)
       i18n (~> 0.6)
       multi_json (~> 1.0)
     builder (3.0.0)
@@ -24,8 +25,8 @@ GEM
     i18n (0.6.0)
     json (1.6.5)
     libv8 (3.3.10.4)
-    mime-types (1.17.2)
-    multi_json (1.0.4)
+    mime-types (1.18)
+    multi_json (1.0.3)
     rake (0.9.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -49,6 +50,5 @@ DEPENDENCIES
   couch_potato!
   rake
   rspec (>= 2.0)
-  therubyracer
   timecop
   tzinfo

--- a/active_support_3_0.lock
+++ b/active_support_3_0.lock
@@ -5,6 +5,7 @@ PATH
       activemodel
       couchrest (>= 1.0.1)
       json (~> 1.6.0)
+      therubyracer
 
 GEM
   remote: http://rubygems.org/
@@ -21,9 +22,9 @@ GEM
       rest-client (~> 1.6.1)
     diff-lcs (1.1.2)
     i18n (0.5.0)
-    json (1.6.5)
+    json (1.6.7)
     libv8 (3.3.10.4)
-    mime-types (1.17.2)
+    mime-types (1.18)
     multi_json (1.0.4)
     rake (0.8.7)
     rest-client (1.6.7)
@@ -49,6 +50,5 @@ DEPENDENCIES
   couch_potato!
   rake
   rspec (>= 2.0)
-  therubyracer
   timecop
   tzinfo

--- a/active_support_3_1.lock
+++ b/active_support_3_1.lock
@@ -5,6 +5,7 @@ PATH
       activemodel
       couchrest (>= 1.0.1)
       json (~> 1.6.0)
+      therubyracer
 
 GEM
   remote: http://rubygems.org/
@@ -24,9 +25,9 @@ GEM
       rest-client (~> 1.6.1)
     diff-lcs (1.1.2)
     i18n (0.6.0)
-    json (1.6.5)
+    json (1.6.7)
     libv8 (3.3.10.4)
-    mime-types (1.17.2)
+    mime-types (1.18)
     multi_json (1.0.3)
     rake (0.9.2)
     rest-client (1.6.7)
@@ -52,6 +53,5 @@ DEPENDENCIES
   couch_potato!
   rake
   rspec (>= 2.0)
-  therubyracer
   timecop
   tzinfo

--- a/active_support_3_2.lock
+++ b/active_support_3_2.lock
@@ -5,6 +5,7 @@ PATH
       activemodel
       couchrest (>= 1.0.1)
       json (~> 1.6.0)
+      therubyracer
 
 GEM
   remote: http://rubygems.org/
@@ -22,9 +23,9 @@ GEM
       rest-client (~> 1.6.1)
     diff-lcs (1.1.3)
     i18n (0.6.0)
-    json (1.6.5)
+    json (1.6.7)
     libv8 (3.3.10.4)
-    mime-types (1.17.2)
+    mime-types (1.18)
     multi_json (1.0.4)
     rake (0.9.2.2)
     rest-client (1.6.7)
@@ -50,6 +51,5 @@ DEPENDENCIES
   couch_potato!
   rake
   rspec (>= 2.0)
-  therubyracer
   timecop
   tzinfo

--- a/couch_potato.gemspec
+++ b/couch_potato.gemspec
@@ -15,12 +15,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.6.0'
   s.add_dependency 'couchrest', '>=1.0.1'
   s.add_dependency 'activemodel'
+  s.add_dependency 'therubyracer'
 
   s.add_development_dependency 'rspec', '>=2.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'tzinfo'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'therubyracer'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
When I use the couch_potato/rspec matchers in my application to test custom map functions etc. I get errors because v8 is required but could not get loaded. Making therubyracer (and libv8) a runtime dependency fixes the error.
