### PR TITLE
Fix errors when fetching deleted documents using the bulk api

### DIFF
--- a/lib/couch_potato/database.rb
+++ b/lib/couch_potato/database.rb
@@ -146,8 +146,7 @@ module CouchPotato
 
     def bulk_load(ids)
       response = couchrest_database.bulk_load ids
-      existing_rows = response['rows'].select{|row| row.key? 'doc'}
-      docs = existing_rows.map{|row| row["doc"]}
+      docs = response['rows'].map{|row| row['doc']}.compact
       docs.each{|doc| doc.database = self}
     end
 

--- a/spec/unit/database_spec.rb
+++ b/spec/unit/database_spec.rb
@@ -73,7 +73,13 @@ describe CouchPotato::Database, 'load' do
     let(:doc1) { DbTestUser.new }
     let(:doc2) { DbTestUser.new }
     let(:response) do
-      {"rows" => [{}, {"doc" => doc1}, {"doc" => doc2}]}
+      {
+        "rows" => [
+          {"doc" => nil, "value" => {"rev" => "10-df5a4021129ebb70f4a111eea1e881ca", "deleted"=> true}},
+          {"doc" => doc1},
+          {"doc" => doc2}
+        ]
+      }
     end
 
     before(:each) do


### PR DESCRIPTION
When you try to fetch a deleted document, the doc attribute is set but has the value null. My commit fixes that and avoids the following exception 'NoMethodError: undefined method `database=' for nil:NilClass'.