### PR TITLE
Support for BigDecimal

### DIFF
--- a/lib/couch_potato/persistence/type_caster.rb
+++ b/lib/couch_potato/persistence/type_caster.rb
@@ -32,6 +32,8 @@ module CouchPotato
             BigDecimal.new(value.to_s.scan(NUMBER_REGEX).join).round unless value.blank?
           elsif type == Float
             value.to_s.scan(NUMBER_REGEX).join.to_f unless value.blank?
+          elsif type == BigDecimal
+            BigDecimal.new(value.to_s) unless value.blank?
           else
             type.json_create value unless value.blank?
           end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -57,6 +57,14 @@ describe 'properties' do
     c.title.should == 3
   end
 
+  it "should persist a big decimal" do
+    require 'bigdecimal'
+    c = BigDecimalContainer.new :number => BigDecimal.new( '42.42' )
+    CouchPotato.database.save_document! c
+    c = CouchPotato.database.load_document c.id
+    c.number.should == BigDecimal.new( '42.42' )
+  end
+
   it "should persist a hash" do
     c = Comment.new :title => {'key' => 'value'}
     CouchPotato.database.save_document! c

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,12 @@ class Comment
   property :title
 end
 
+class BigDecimalContainer
+  include CouchPotato::Persistence
+
+  property :number, :type => BigDecimal
+end
+
 def recreate_db
   CouchPotato.couchrest_database.recreate!
 end


### PR DESCRIPTION
Floats are not the best when it comes to arithmetic operations so therefore I added BigDecimal support along with a test. Now you can use BigDecimal as the type of a property:
`property :number, :type => BigDecimal`
