### PR TITLE
Support property default values returned by Procs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Properties can have a default value:
       include CouchPotato::Persistence
 
       property :active, :default => true
+      property :signed_up, :default => Proc.new { Time.now }
     end
 
 Now you can save your objects. All database operations are encapsulated in the CouchPotato::Database class. This separates your domain logic from the database access logic which makes it easier to write tests and also keeps you models smaller and cleaner.

--- a/lib/couch_potato/persistence/simple_property.rb
+++ b/lib/couch_potato/persistence/simple_property.rb
@@ -56,7 +56,11 @@ module CouchPotato
             load_attribute_from_document(name) unless instance_variable_defined?("@#{name}")
             value = instance_variable_get("@#{name}")
             if value.nil? && !options[:default].nil?
-              default = clone_attribute(options[:default])
+              default = if options[:default].respond_to?(:call)
+                options[:default].call
+              else
+                clone_attribute(options[:default])
+              end
               self.instance_variable_set("@#{name}", default)
               default
             else

--- a/spec/default_property_spec.rb
+++ b/spec/default_property_spec.rb
@@ -6,6 +6,7 @@ class Test
   property :test, :default => 'Test value'
   property :complex, :default => [1, 2, 3]
   property :false_value, :default => false
+  property :proc, :default => Proc.new { 1 + 2 }
 end
 
 describe 'default properties' do
@@ -40,5 +41,10 @@ describe 'default properties' do
   it "uses the default value also if the default is false" do
     t = Test.new
     t.false_value.should == false
+  end
+
+  it "uses the return value of a Proc given as the default" do
+    t = Test.new
+    t.proc.should == 3
   end
 end


### PR DESCRIPTION
Title pretty much says it all. Allow Procs to be given as property default values, call the Proc to get the default value when needed.
