### PR TITLE
Compatibility between Hash and HashWithIndifferentAccess

### DIFF
--- a/lib/couch_potato/persistence/type_caster.rb
+++ b/lib/couch_potato/persistence/type_caster.rb
@@ -34,6 +34,8 @@ module CouchPotato
             value.to_s.scan(NUMBER_REGEX).join.to_f unless value.blank?
           elsif type == BigDecimal
             BigDecimal.new(value.to_s) unless value.blank?
+          elsif type == Hash
+            value.to_hash unless value.blank?
           else
             type.json_create value unless value.blank?
           end

--- a/spec/fixtures/person.rb
+++ b/spec/fixtures/person.rb
@@ -3,4 +3,5 @@ class Person
   
   property :name, :type => Address
   property :ship_address
+  property :information, :type => Hash
 end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -72,6 +72,13 @@ describe 'properties' do
     c.title.should == {'key' => 'value'}
   end
 
+  it "should persist a HashWithIndifferentAccess" do
+    c = Person.new :information => HashWithIndifferentAccess.new({"key" => "value"})
+    CouchPotato.database.save_document! c
+    c = CouchPotato.database.load_document c.id
+    c.information.should == {'key' => 'value'}
+  end
+
   def it_should_persist value
     c = Comment.new :title => value
     CouchPotato.database.save_document! c


### PR DESCRIPTION
This addresses an issue with hashes of type ActiveSupport::HashWithIndifferentAccess not being able to be cast by the TypeCaster class.
