### PR TITLE
makes cast_native cast floats with no leading digits.

### DIFF
--- a/lib/couch_potato/persistence/type_caster.rb
+++ b/lib/couch_potato/persistence/type_caster.rb
@@ -1,7 +1,7 @@
 module CouchPotato
   module Persistence
     class TypeCaster #:nodoc:
-      NUMBER_REGEX = /-?\d+\.?\d*/
+      NUMBER_REGEX = /-?\d*\.?\d*/
 
       def cast(value, type)
         if type == :boolean

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -12,6 +12,7 @@ class Watch
   property :custom_address, :type => [Address]
   property :overwritten_read
   property :overwritten_write
+  property :diameter, :type => Float
 
   def overwritten_read
     super.to_s
@@ -71,6 +72,20 @@ describe 'properties' do
     CouchPotato.database.save_document! c
     c = CouchPotato.database.load_document c.id
     c.title.should == 3
+  end
+
+  it "should persist a float with leading digits" do
+    w = Watch.new :diameter => "46.5"
+    CouchPotato.database.save_document! w
+    w = CouchPotato.database.load_document w.id
+    w.diameter.should == 46.5
+  end
+
+  it "should persist a float with no leading digits" do
+    w = Watch.new :diameter => ".465"
+    CouchPotato.database.save_document! w
+    w = CouchPotato.database.load_document w.id
+    w.diameter.should == 0.465
   end
 
   it "should persist a big decimal" do


### PR DESCRIPTION
This pull request makes the `cast_native` function properly cast floats with no leading digits, to make it more consistent with ruby's `to_f` method. In ruby, `".333".to_f == 0.333` but `cast_native(".333", Float) === 333.0`

Here is an example script:

``` ruby
require 'couch_potato'

CouchPotato::Config.database_name = 'mytestdb'

class Model
  include CouchPotato::Persistence

  property :number, type: Float
end

model = Model.new({"number" => "0.300"})
#model.number == 0.3

model2 = Model.new({"number" => ".300"})
#model2.number == 300.0 before the fix
#model2.number == 0.3 after the fix
```
