### PR TITLE
Update view if RestClient responds with HTTP 500

### DIFF
--- a/lib/couch_potato/view/view_query.rb
+++ b/lib/couch_potato/view/view_query.rb
@@ -20,7 +20,7 @@ module CouchPotato
         update_view unless view_has_been_updated?
         begin
           query_view parameters
-        rescue RestClient::ResourceNotFound
+        rescue RestClient::ResourceNotFound, RestClient::InternalServerError
           update_view
           retry
         end


### PR DESCRIPTION
We have a layer in our stack that caches models which can also throw a `HTTP 500`. Updating the view in this case works.

But maybe this shouldn't really be in upstream… your choice.
