### PR TITLE
New CouchPotato::RSpec::HavePropertyMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,25 @@ For stubbing out the database couch potato offers some helpers:
     CouchPotato.database.view(Comment.by_commenter_id('23)) # => [:comment1, :comment2]
     CouchPotato.database.first(Comment.by_commenter_id('23)) # => :comment1
 
+##### Testing Properties
+
+Couch Potato provides custom RSpec matchers for testing properties.  For example:
+
+    class User
+      include CouchPotato::Persistence
+
+      property :name, :default => "John Doe"
+      property :active, :type => :boolean
+    end
+
+    # RSpec
+    require 'couch_potato/rspec'
+
+    describe User do
+      it { should have_property(:name).with_options(:default => "John Doe")
+      it { should have_property(:active).of_type(:boolean) }
+    end
+
 ##### Testing map/reduce functions
 
 Couch Potato provides custom RSpec matchers for testing the map and reduce functions of your views. For example you can do this:

--- a/lib/couch_potato/rspec/matchers.rb
+++ b/lib/couch_potato/rspec/matchers.rb
@@ -29,6 +29,7 @@ require 'couch_potato/rspec/matchers/map_to_matcher'
 require 'couch_potato/rspec/matchers/reduce_to_matcher'
 require 'couch_potato/rspec/matchers/map_reduce_to_matcher'
 require 'couch_potato/rspec/matchers/list_as_matcher'
+require 'couch_potato/rspec/matchers/have_property_matcher'
 
 module RSpec
   module Matchers
@@ -50,6 +51,10 @@ module RSpec
 
     def map_reduce(*docs)
       CouchPotato::RSpec::MapReduceToProxy.new(docs)
+    end
+
+    def have_property(name)
+      CouchPotato::RSpec::HavePropertyMatcher.new(name)
     end
   end
 end

--- a/lib/couch_potato/rspec/matchers/have_property_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/have_property_matcher.rb
@@ -1,0 +1,87 @@
+module CouchPotato
+  module RSpec
+    class HavePropertyMatcher
+
+      def initialize(name)
+        @name    = name
+        @options = {}
+      end
+
+      def of_type(property_type)
+        @options[:type] = property_type
+        self
+      end
+
+      def with_options(opts={})
+        %w(default).each do |opt|
+          opt = opt.to_sym
+          @options[opt] = opts[opt] if opts.key?(opt)
+        end
+        self
+      end
+
+      def matches?(subject)
+        @subject = subject
+        property_exists? && correct_property_type? && correct_default?
+      end
+
+      def failure_message_for_should
+        "Expected #{expectation}" + help_text
+      end
+
+      def failure_message_for_should_not
+        "Did not expect #{expectation}" + help_text
+      end
+
+      protected
+
+        def property_exists?
+          !matched_property.nil?
+        end
+
+        def correct_property_type?
+          return true unless @options.key?(:type)
+
+          if matched_property.type.to_s == @options[:type].to_s
+            true
+          else
+            @help = "#{@subject} has a property named `#{@name}' " +
+              "of type #{matched_property.type}, " +
+              "not #{@options[:type]}"
+            false
+          end
+        end
+
+        def correct_default?
+          return true unless @options.key?(:default)
+          val = @subject.new.send(matched_property.name)
+
+          if val == @options[:default]
+            true
+          else
+            @help = "#{@subject} has a property named `#{@name}' " +
+              "with default #{val}, " +
+              "not #{@options[:default]}"
+            false
+          end
+        end
+
+        def matched_property
+          @matched_property ||= begin
+            @subject.properties.detect { |p| p.name == @name }
+          end
+        end
+
+        def expectation
+          str = "#{@subject} to have a property named `#{@name}'"
+          str << " of type #{@options[:type]}" if @options.key?(:type)
+          str << " of default #{@options[:default]}" if @options.key?(:default)
+          str
+        end
+
+        def help_text
+          @help ? " (#{@help})" : ""
+        end
+    end
+  end
+end

--- a/spec/unit/rspec_matchers_spec.rb
+++ b/spec/unit/rspec_matchers_spec.rb
@@ -267,3 +267,59 @@ describe CouchPotato::RSpec::ListAsMatcher do
     end
   end
 end
+
+class HavePropertyMatcherTest
+  include CouchPotato::Persistence
+
+  property :foo, type: :boolean
+  property :bar, default: "hello world"
+end
+
+describe CouchPotato::RSpec::HavePropertyMatcher do
+  subject { HavePropertyMatcherTest }
+
+  it "accepts an existing property" do
+    expect(subject).to have_property(:foo)
+  end
+
+  it "rejects a nonexisting property" do
+    expect(subject).not_to have_property(:faz)
+  end
+
+  it "should have a nice error message" do
+    lambda {
+      expect(subject).to have_property(:baz)
+    }.should raise_error("Expected HavePropertyMatcherTest to have a property named `baz'")
+  end
+
+  it "should have a helpful error message" do
+    lambda {
+      expect(subject).to have_property(:foo).of_type(:fixnum)
+    }.should raise_error("Expected HavePropertyMatcherTest to have a property " +
+      "named `foo' of type fixnum (HavePropertyMatcherTest has a property " +
+      "named `foo' of type boolean, not fixnum)")
+  end
+
+  describe "#of_type" do
+    it "accepts a property of the correct data type" do
+      expect(subject).to have_property(:foo).of_type(:boolean)
+    end
+
+    it "rejects a property of the incorrect data type" do
+      expect(subject).not_to have_property(:foo).of_type(:fixnum)
+    end
+  end
+
+  context "#with_options" do
+    describe "default" do
+      it "accepts a property with the correct default" do
+        expect(subject).to have_property(:bar).with_options(default: "hello world")
+      end
+
+      it "rejects a property with an incorrect default" do
+        expect(subject).not_to have_property(:bar).with_options(default: 123)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
:beers: 

``` ruby
class User
  include CouchPotato::Persistence

  property :name, :default => "John Doe"
  property :active, :type => :boolean
end
```

``` ruby
require 'couch_potato/rspec'

describe User do
  it { should have_property(:name).with_options(:default => "John Doe")
  it { should have_property(:active).of_type(:boolean) }
end
```
