### PR TITLE
Removing the dependency to json/add/core

### DIFF
--- a/lib/couch_potato.rb
+++ b/lib/couch_potato.rb
@@ -1,6 +1,5 @@
 require 'couchrest'
 require 'json'
-require 'json/add/core'
 
 require 'ostruct'
 


### PR DESCRIPTION
Need to remove the json/add/core dependency, because there is a bug in that library.
Calling the `.to_json` method on a symbol will not return the expected JSON.

```
2.1.1 :001 > require 'json/add/core'
 => true 
2.1.1 :002 > :test.to_json
 => "{\"json_class\":\"Symbol\",\"s\":\"test\"}" 
```

So on calling the `.to_json` without including the json/add/core, the result is correct.

```
2.1.1 :001 > require 'json'
 => true 
2.1.1 :002 > :test.to_json
 => "\"test\"" 
```

The bug occures when other libraries are calling the `.to_json` method. In my case, I can't use the poltergeist gem for headless capybara testing.

It would be nice, if the change could get included into the gem on rubygems.
