### PR TITLE
Replace deprecated stub call with double

### DIFF
--- a/lib/couch_potato/rspec/stub_db.rb
+++ b/lib/couch_potato/rspec/stub_db.rb
@@ -40,7 +40,7 @@ module CouchPotato::RSpec
 
   module StubDb
     def stub_db(options = {})
-      db = stub('db', options)
+      db = double('db', options)
       db.extend CouchPotato::RSpec::StubView
       CouchPotato.stub(:database => db)
       db


### PR DESCRIPTION
Newer versions of rspec-mocks have deprecated `stub` in favor of `double`, resulting in warning messages when using `stub_db` in apps that use couch_potato (see https://github.com/rspec/rspec-mocks/pull/233). 

After simply swapping out `stub` for `double` in `stub_db`, all specs still pass and everything appears fine, and the warnings are gone.
