### PR TITLE
Revert moving lib out of views in ViewQuery, fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ You can also pass in custom map/reduce functions with the custom view spec:
 commonJS modules can also be used in custom views:
 
     class User
-      view :all, :map => "function(doc) { emit(null, require("lib/test").test)}", :lib => {:test => "exports.test = 'test'"}, :include_docs => true, :type => :custom
+      view :all, :map => "function(doc) { emit(null, require("views/lib/test").test)}", :lib => {:test => "exports.test = 'test'"}, :include_docs => true, :type => :custom
     end
 
 If you don't want the results to be converted into models the raw view is your friend:

--- a/lib/couch_potato/view/view_query.rb
+++ b/lib/couch_potato/view/view_query.rb
@@ -43,19 +43,17 @@ module CouchPotato
         design_doc = @database.get "_design/#{@design_document_name}" rescue nil
         original_views = design_doc && design_doc['views'].dup
         original_lists = design_doc && design_doc['lists'] && design_doc['lists'].dup
-        original_lib = design_doc && design_doc['lib'] && design_doc['lib'].dup
         view_updated unless design_doc.nil?
         design_doc ||= empty_design_document
         design_doc['views'][@view_name.to_s] = view_functions
         if @lib
-          design_doc['lib'] = (design_doc['lib'] || {}).merge(@lib)
+          design_doc['views']['lib'] = (design_doc['views']['lib'] || {}).merge(@lib)
         end
         if @list_function
           design_doc['lists'] ||= {}
           design_doc['lists'][@list_name.to_s] = @list_function
         end
-        @database.save_doc(design_doc) if original_views != design_doc['views'] ||
-          original_lists != design_doc['lists'] || original_lib != design_doc['lib']
+        @database.save_doc(design_doc) if original_views != design_doc['views'] || original_lists != design_doc['lists']
       end
 
       def view_functions

--- a/spec/unit/view_query_spec.rb
+++ b/spec/unit/view_query_spec.rb
@@ -16,8 +16,7 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
     db = mock 'db', :get => nil, :view => nil
 
     db.should_receive(:save_doc).with(
-      'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}},
-      'lib' => {'test' => '<lib_code>'},
+      'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}, 'lib' => {'test' => '<lib_code>'}},
       'lists' => {},
       "_id" => "_design/design",
       "language" => "javascript"
@@ -73,7 +72,7 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it "does not update a view when the lib function hasn't changed" do
-    db = mock 'db', :get => {'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}, 'lib' => {'test' => '<lib_code>'}}, :view => nil
+    db = mock 'db', :get => {'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}, 'lib' => {'test' => '<lib_code>'}}}, :view => nil
 
     db.should_not_receive(:save_doc)
 
@@ -101,24 +100,24 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it "doesn't override libs with different names" do
-    db = mock 'db', :get => {'views' => {'view5' => {'map' => '<map_code>'}}, 'lib' => {'test' => "<test_lib>"}}, :view => nil
+    db = mock 'db', :get => {'views' => {'view5' => {'map' => '<map_code>'}, 'lib' => {'test' => "<test_lib>"}}}, :view => nil
     db.should_receive(:save_doc).with({
       'views' => {
-         'view5' => {'map' => '<map_code>'},
-      },
-      'lib' => {'test' => '<test_lib>', 'test1' => '<test1_lib>'}
+        'view5' => {'map' => '<map_code>'},
+        'lib' => {'test' => '<test_lib>', 'test1' => '<test1_lib>'}
+      }
     })
     CouchPotato::View::ViewQuery.new(db, 'design', {:view5 => {:map => '<map_code>'}}, nil, {'test1' => '<test1_lib>'}).query_view!
   end
 
   it "overrides libs with the same name" do
-    db = mock 'db', :get => {'views' => {'view6' => {'map' => '<map_code>'}}, 'lib' => {'test' => "<test_lib>"}}, :view => nil
+    db = mock 'db', :get => {'views' => {'view6' => {'map' => '<map_code>'}, 'lib' => {'test' => "<test_lib>"}}}, :view => nil
 
     db.should_receive(:save_doc).with({
       'views' => {
-         'view6' => {'map' => '<map_code>'}
+        'view6' => {'map' => '<map_code>'},
+        'lib' => {'test' => '<test1_lib>'}
       },
-      'lib' => {'test' => '<test1_lib>'}
     })
 
     CouchPotato::View::ViewQuery.new(db, 'design', {:view6 => {:map => '<map_code>'}}, nil, {'test' => '<test1_lib>'}).query_view!


### PR DESCRIPTION
CommonJS modules can be under the root `lib` for some uses, but `map` functions in views are only allowed to `require` from `views/lib` (see http://couchdb-13.readthedocs.org/en/latest/1.1/commonjs/ ). The couch_potato RSpec matcher specs still passed because `MapToMatcher` and `MapReduceToMatcher` define their own javascript `require` function (and the specs still referenced `views/lib/...`), but moving `views/lib` to `lib` in the design docs causes the view to fail in couchdb and not emit any results.

The CommonJS `require` example in README also had a typo which probably caused confusion.

Does having `lib` under `views` cause a different problem?
