### PR TITLE
Handle CommonJS modules with module.exports as well as exports

### DIFF
--- a/lib/couch_potato/rspec/matchers/map_reduce_to_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/map_reduce_to_matcher.rb
@@ -75,14 +75,15 @@ module CouchPotato
 
           // Map the input docs
           var require = function(modulePath) {
-            var exports = {};
+            var module = {exports: {}};
+            var exports = module.exports;
             var pathArray = modulePath.split("/").slice(2);
             var result = lib;
             for (var i in pathArray) {
-              result = result[pathArray[i]]
+              result = result[pathArray[i]];
             }
             eval(result);
-            return exports;
+            return module.exports;
           }
 
           var mapResults = [];

--- a/lib/couch_potato/rspec/matchers/map_to_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/map_to_matcher.rb
@@ -28,14 +28,15 @@ module CouchPotato
           var lib = #{view_spec.respond_to?(:lib) && view_spec.lib.to_json};
           var result = [];
           var require = function(modulePath) {
-            var exports = {};
+            var module = {exports: {}};
+            var exports = module.exports;
             var pathArray = modulePath.split("/").slice(2);
             var result = lib;
             for (var i in pathArray) {
-              result = result[pathArray[i]]
+              result = result[pathArray[i]];
             }
             eval(result);
-            return exports;
+            return module.exports;
           }
 
           var emit = function(key, value) {

--- a/spec/unit/rspec_matchers_spec.rb
+++ b/spec/unit/rspec_matchers_spec.rb
@@ -36,10 +36,18 @@ describe CouchPotato::RSpec::MapToMatcher do
     spec.should map({}).to([nil, "2013-05-17T15:00:00.000Z"])
   end
 
-  it "should work with commonJS modules" do
+  it "should work with commonJS modules that use 'exports'" do
     spec = stub(
       :map_function => "function(doc) { var test = require('views/lib/test'); emit(null, test.test); }",
       :lib => {:test => "exports.test = 'test';"}
+    )
+    spec.should map({}).to([nil, "test"])
+  end
+
+  it "should work with commonJS modules that use 'module.exports'" do
+    spec = stub(
+      :map_function => "function(doc) { var test = require('views/lib/test'); emit(null, test.test); }",
+      :lib => {:test => "module.exports.test = 'test';"}
     )
     spec.should map({}).to([nil, "test"])
   end
@@ -137,11 +145,19 @@ describe CouchPotato::RSpec::MapReduceToMatcher do
     spec.should map_reduce({}).to({"key" => nil, "value" => "2013-05-17T15:00:00.000Z"})
   end
 
-  it "should handle CommonJS requires" do
+  it "should handle CommonJS requires for modules that use 'exports'" do
     spec = stub(
       :map_function => "function() { var test = require('views/lib/test'); emit(null, test.test); }",
       :reduce_function => "function(keys, values) { return 'test' }",
       :lib => {:test => "exports.test = 'test'"})
+    spec.should map_reduce({}).to({"key" => nil, "value" => "test"})
+  end
+
+  it "should handle CommonJS requires for modules that use 'module.exports'" do
+    spec = stub(
+      :map_function => "function() { var test = require('views/lib/test'); emit(null, test.test); }",
+      :reduce_function => "function(keys, values) { return 'test' }",
+      :lib => {:test => "module.exports.test = 'test'"})
     spec.should map_reduce({}).to({"key" => nil, "value" => "test"})
   end
 


### PR DESCRIPTION
This came about because my team was trying to include [moment-timezone](https://github.com/moment/moment-timezone/) in a view as a CommonJS module. Actually running the view in couchdb worked fine, but our map/reduce specs did not work.

It turned out that moment-timezone exports its functionality for CommonJS using the `module.exports` object instead of the `exports` object. Both appear to be valid ways for libraries to support CommonJS, though I haven't had luck finding an official spec that explains this, only several blog posts and explanations like [this](http://stackoverflow.com/a/5311377).
