### PR TITLE
reuse existing connection when querying lists

### DIFF
--- a/lib/couch_potato/view/view_query.rb
+++ b/lib/couch_potato/view/view_query.rb
@@ -82,7 +82,7 @@ module CouchPotato
 
       def query_view(parameters)
         if @list_name
-          CouchRest.get CouchRest.paramify_url(CouchPotato.full_url_to_database + "/_design/#{@design_document_name}/_list/#{@list_name}/#{@view_name}", parameters)
+          @database.connection.get CouchRest.paramify_url("/#{@database.name}/_design/#{@design_document_name}/_list/#{@list_name}/#{@view_name}", parameters)
         else
           @database.view view_url, parameters
         end

--- a/spec/unit/view_query_spec.rb
+++ b/spec/unit/view_query_spec.rb
@@ -1,20 +1,19 @@
 require 'spec_helper'
 
 describe CouchPotato::View::ViewQuery, 'query_view!' do
+  let(:db) { double 'db', :get => nil, view: nil, :save_doc => nil, 
+    connection: double.as_null_object, name: nil }
+
   before(:each) do
-    allow(CouchRest).to receive_messages(:get => nil)
     CouchPotato::View::ViewQuery.clear_cache
   end
 
   it "does not pass a key if conditions are empty" do
-    db = double 'db', :get => nil, :save_doc => nil
     expect(db).to receive(:view).with(anything, {})
     CouchPotato::View::ViewQuery.new(db, '', {:view0 => {}}).query_view!
   end
 
   it 'updates a view if it does not exist' do
-    db = double 'db', :get => nil, :view => nil
-
     expect(db).to receive(:save_doc).with(
       'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}, 'lib' => {'test' => '<lib_code>'}},
       'lists' => {},
@@ -26,7 +25,6 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it 'only updates a view once' do
-    db = double :db, view: nil
     allow(db).to receive(:get).and_return({'views' => {}}, {'views' => {}, x: 1}) # return something different on the second call otherwise it would never try to update the views twice
     query = CouchPotato::View::ViewQuery.new(db, 'design', {:view => {:map => '<map_code>', :reduce => '<reduce_code>'}})
 
@@ -36,7 +34,6 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it 'updates a view again after clearing the view cache' do
-    db = double :db, view: nil
     allow(db).to receive(:get).and_return({'views' => {}}, {'views' => {}, x: 1}) # return something different on the second call otherwise it would never try to update the views twice
     query = CouchPotato::View::ViewQuery.new(db, 'design', {:view => {:map => '<map_code>', :reduce => '<reduce_code>'}})
 
@@ -48,8 +45,6 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it 'updates a view in erlang if it does not exist' do
-    db = double 'db', :get => nil, :view => nil
-
     expect(db).to receive(:save_doc).with(
       'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}},
       'lists' => {}, "_id" => "_design/design", "language" => "erlang")
@@ -60,19 +55,19 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it "does not update a view when the views object haven't changed" do
-    db = double 'db', :get => {'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}})
     expect(db).not_to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', {:view => {:map => '<map_code>', :reduce => '<reduce_code>'}}, nil, nil).query_view!
   end
 
   it "does not update a view when the list function hasn't changed" do
-    db = double 'db', :get => {'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}, 'lists' => {'list0' => '<list_code>'}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}, 'lists' => {'list0' => '<list_code>'}})
     expect(db).not_to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', {:view => {:map => '<map_code>', :reduce => '<reduce_code>'}}, :list0 => '<list_code>').query_view!
   end
 
   it "does not update a view when the lib function hasn't changed" do
-    db = double 'db', :get => {'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}, 'lib' => {'test' => '<lib_code>'}}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}, 'lib' => {'test' => '<lib_code>'}}})
 
     expect(db).not_to receive(:save_doc)
 
@@ -80,19 +75,19 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it "updates a view when the map function has changed" do
-    db = double 'db', :get => {'views' => {'view2' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view2' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}})
     expect(db).to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', :view2 => {:map => '<new map_code>', :reduce => '<reduce_code>'}).query_view!
   end
 
   it "updates a view when the map function has changed" do
-    db = double 'db', :get => {'views' => {'view3' => {'map' => '<map_code>'}}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view3' => {'map' => '<map_code>'}}})
     expect(db).to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', :view3 => {:map => '<new map_code>'}).query_view!
   end
 
   it "updates a view when the lib hash has changed" do
-    db = double 'db', :get => {'views' => {'view4' => {'map' => '<map_code>'}}}, 'lib' => {'test' => "<test_lib>"}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view4' => {'map' => '<map_code>'}}}, 'lib' => {'test' => "<test_lib>"})
 
     expect(db).to receive(:save_doc)
 
@@ -100,7 +95,7 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it "doesn't override libs with different names" do
-    db = double 'db', :get => {'views' => {'view5' => {'map' => '<map_code>'}, 'lib' => {'test' => "<test_lib>"}}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view5' => {'map' => '<map_code>'}, 'lib' => {'test' => "<test_lib>"}}})
     expect(db).to receive(:save_doc).with({
       'views' => {
         'view5' => {'map' => '<map_code>'},
@@ -111,7 +106,7 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it "overrides libs with the same name" do
-    db = double 'db', :get => {'views' => {'view6' => {'map' => '<map_code>'}, 'lib' => {'test' => "<test_lib>"}}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view6' => {'map' => '<map_code>'}, 'lib' => {'test' => "<test_lib>"}}})
 
     expect(db).to receive(:save_doc).with({
       'views' => {
@@ -124,54 +119,55 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
   end
 
   it "does not pass in reduce or lib keys if there is no lib or reduce object" do
-    db = double 'db', :get => {'views' => {}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {}})
     expect(db).to receive(:save_doc).with('views' => {'view7' => {'map' => '<map code>'}})
     CouchPotato::View::ViewQuery.new(db, 'design', :view7 => {:map => '<map code>', :reduce => nil}).query_view!
   end
 
   it "updates a view when the reduce function has changed" do
-    db = double 'db', :get => {'views' => {'view8' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}}, :view => nil
+    allow(db).to receive(:get).and_return({'views' => {'view8' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}})
     expect(db).to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', :view8 => {:map => '<map_code>', :reduce => '<new reduce_code>'}).query_view!
   end
 
   it "updates a view when the list function has changed" do
-    db = double 'db', :get => {
+    allow(db).to receive(:get).and_return({
       'views' => {'view9' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}},
       'lists' => {'list1' => '<list_code>'}
-      }, :view => nil
+      })
     expect(db).to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', {:view9 => {:map => '<map_code>', :reduce => '<reduce_code>'}}, :list1 => '<new_list_code>').query_view!
   end
 
   it "updates a view when there wasn't a list function but now there is one" do
-    db = double 'db', :get => {
+    allow(db).to receive(:get).and_return({
       'views' => {'view10' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}
-      }, :view => nil
+      })
     expect(db).to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', {:view10 => {:map => '<map_code>', :reduce => '<reduce_code>'}}, :list1 => '<new_list_code>').query_view!
   end
 
   it "does not update a view when there is a list function but no list function is passed" do
-    db = double 'db', :get => {
+    allow(db).to receive(:get).and_return({
       'views' => {'view11' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}},
       'lists' => {'list1' => '<list_code>'}
-      }, :view => nil
+      })
     expect(db).not_to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', {:view11 => {:map => '<map_code>', :reduce => '<reduce_code>'}}, {}).query_view!
   end
 
   it "does not update a view when there were no lists before and no list function is passed" do
-    db = double 'db', :get => {
+    allow(db).to receive(:get).and_return({
       'views' => {'view12' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}
-      }, :view => nil
+      })
     expect(db).not_to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', {:view12 => {:map => '<map_code>', :reduce => '<reduce_code>'}}, {}).query_view!
   end
 
-  it "queries CouchRest directly when querying a list" do
-    db = double('db').as_null_object
-    expect(CouchRest).to receive(:get).with('http://127.0.0.1:5984/couch_potato_test/_design/my_design/_list/list1/view13?key=1')
+  it "queries the database directly when querying a list" do
+    allow(db).to receive(:name){'my_database'}
+
+    expect(db.connection).to receive(:get).with('/my_database/_design/my_design/_list/list1/view13?key=1')
     CouchPotato::View::ViewQuery.new(db, 'my_design', {:view13 => {:map => '<map_code>', :reduce => '<reduce_code>'}}, :list1 => '<new_list_code>').query_view!(:key => 1)
   end
 


### PR DESCRIPTION
instead of creating a extra one.

also refactored the view query spec a bit