### PR TITLE
update to couchrest.2.0.0.rc3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ gemfile:
   - gemfiles/active_support_4_0
   - gemfiles/active_support_4_1
   - gemfiles/active_support_4_2
+before_install:
+  gem install bundler --version 1.11.2
 before_script:
   - sudo sh -c 'echo "[native_query_servers]" >> /etc/couchdb/local.ini'
   - sudo sh -c 'echo "erlang = {couch_native_process, start_link, []}" >> /etc/couchdb/local.ini'

--- a/couch_potato.gemspec
+++ b/couch_potato.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
 
   s.add_dependency 'json', '~> 1.6'
-  s.add_dependency 'couchrest', '~>2.0.0.rc2'
+  s.add_dependency 'couchrest', '~>2.0.0.rc3'
   s.add_dependency 'activemodel', '~> 4.0'
 
   s.add_development_dependency 'rspec', '~>3.2.0'

--- a/lib/couch_potato/database.rb
+++ b/lib/couch_potato/database.rb
@@ -111,13 +111,9 @@ module CouchPotato
       if id.is_a?(Array)
         bulk_load id
       else
-        begin
-          instance = couchrest_database.get(id)
-          instance.database = self
-          instance
-        rescue(CouchRest::NotFound)
-          nil
-        end
+        instance = couchrest_database.get(id)
+        instance.database = self if instance
+        instance
       end
     end
     alias_method :load, :load_document

--- a/spec/destroy_spec.rb
+++ b/spec/destroy_spec.rb
@@ -21,8 +21,8 @@ describe 'destroy' do
   end
   
   it "should remove the document from the database" do
-    expect {
-      expect(CouchPotato.couchrest_database.get(@comment_id)).to
+    expect{
+      CouchPotato.couchrest_database.get!(@comment_id)
     }.to raise_error(CouchRest::NotFound)
   end
   

--- a/spec/unit/database_spec.rb
+++ b/spec/unit/database_spec.rb
@@ -105,7 +105,7 @@ describe CouchPotato::Database, 'load!' do
   let(:db) { CouchPotato::Database.new(double('couchrest db', :info => nil).as_null_object) }
 
   it "should raise an error if no document found" do
-    allow(db.couchrest_database).to receive(:get).and_raise(CouchRest::NotFound)
+    allow(db.couchrest_database).to receive(:get).and_return(nil)
     expect {
       db.load! '1'
     }.to raise_error(CouchPotato::NotFound)


### PR DESCRIPTION
which returns nil for get('invalid') instead of raising an exception.