### PR TITLE
Add support for key/keys/startkey/endkey options to MapReduceToMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,14 +640,18 @@ describe User, 'views' do
   end
 
   it "should map/reduce users to the oldest age by name" do
-    docs = [User.new(:name => "John", :age => 25), User.new(:name => "John", :age => 30), User.new(:name => "Jane", :age => 20)]
-    User.oldest_by_name.should map_reduce(docs).with_options(:group => true).to(
-      {"key" => "John", "value" => 30}, {"key" => "Jane", "value" => 20})
+    docs = [
+      User.new(:name => "Andy", :age => 30),
+      User.new(:name => "John", :age => 25),
+      User.new(:name => "John", :age => 30),
+      User.new(:name => "Jane", :age => 20)]
+    User.oldest_by_name.should map_reduce(docs).with_options(:group => true, :startkey => "Jane").to(
+      {"key" => "Jane", "value" => 20}, {"key" => "John", "value" => 30})
   end
 end
 ```
 
-This will actually run your map/reduce functions in a JavaScript interpreter, passing the arguments as JSON and converting the results back to Ruby. `map_reduce` specs map the input documents, reduce the emitted keys/values, and rereduce the results while also respecting the `:group` and `:group_level` couchdb options. For more examples see the [spec](http://github.com/langalex/couch_potato/blob/master/spec/unit/rspec_matchers_spec.rb).
+This will actually run your map/reduce functions in a JavaScript interpreter, passing the arguments as JSON and converting the results back to Ruby. `map_reduce` specs map the input documents, reduce the emitted keys/values, and rereduce the results while also respecting the `:group`, `:group_level`, `:key`, `:keys`, `:startkey`, and `:endkey` couchdb options. For more examples see the [spec](http://github.com/langalex/couch_potato/blob/master/spec/unit/rspec_matchers_spec.rb).
 
 In order for this to work you must have the `js` executable in your PATH. This is usually part of the _spidermonkey_ package/port. (On MacPorts that's _spidemonkey_, on Linux it could be one of _libjs_, _libmozjs_ or _libspidermonkey_). When you installed CouchDB via your packet manager Spidermonkey should already be there.
 

--- a/spec/unit/rspec_matchers_spec.rb
+++ b/spec/unit/rspec_matchers_spec.rb
@@ -133,10 +133,10 @@ describe CouchPotato::RSpec::MapReduceToMatcher do
         }"
     )
     @docs = [
-      {:name => "a", :age => 25, :numbers => [1, 2]},
-      {:name => "b", :age => 25, :numbers => [3, 4]},
-      {:name => "c", :age => 26, :numbers => [5, 6]},
-      {:name => "d", :age => 27, :numbers => [7, 8]}]
+      {:age => 25, :name => "a", :numbers => [1, 2]},
+      {:age => 25, :name => "b", :numbers => [3, 4]},
+      {:age => 26, :name => "c", :numbers => [5, 6]},
+      {:age => 27, :name => "d", :numbers => [7, 8]}]
   end
 
   it "should handle date return values" do
@@ -233,6 +233,46 @@ describe CouchPotato::RSpec::MapReduceToMatcher do
         {:name => "a", :number => 2},
         {:name => "a", :number => 3}]
       expect(@view_spec).to map_reduce(docs).to({"key" => nil, "value" => {"rereduce_values" => [[1], [2, 3]]}})
+    end
+  end
+
+  describe "with key option" do
+    it "should return only results for the given key" do
+      options = {:key => [25, "a"]}
+      results = {"key" => nil, "value" => 2}
+      @view_spec.should map_reduce(@docs).with_options(options).to(results)
+    end
+  end
+
+  describe "with keys option" do
+    it "should return only results for the given keys" do
+      options = {:group => true, :keys => [[25, "b"], [26, "c"]]}
+      results = [{"key" => [25, "b"], "value" => 4}, {"key" => [26, "c"], "value" => 6}]
+      @view_spec.should map_reduce(@docs).with_options(options).to(*results)
+    end
+  end
+
+  describe "with startkey (but no endkey) option" do
+    it "should return results with keys from the startkey on" do
+      options = {:group_level => 1, :startkey => [26]}
+      results = [{"key" => [26], "value" => 6}, {"key" => [27], "value" => 8}]
+      @view_spec.should map_reduce(@docs).with_options(options).to(*results)
+    end
+  end
+
+  describe "with endkey (but no startkey) option" do
+    it "should return results with keys up to the endkey" do
+      options = {:endkey => [26, "c"]}
+      results = {"key" => nil, "value" => 6}
+      @view_spec.should map_reduce(@docs).with_options(options).to(results)
+    end
+  end
+
+  describe "with startkey and endkey options" do
+    it "should return only results in the given key range" do
+      options = {:group => true, :startkey => [25, "b"], :endkey => [26, "c"]}
+      results = [{"key" => [25, "b"], "value" => 4}, {"key" => [26, "c"], "value" => 6}]
+      @view_spec.should map_reduce(@docs).with_options(options).to(*results)
     end
   end
 


### PR DESCRIPTION
This adds support for filtering map/reduce results in specs by `key`, `keys`, and `startkey` and/or `endkey` (in addition to the already supported `group` and `group_level` options). This enables specifying view results by map/reducing over a set of documents, and making assertions about the results when that same set of documents is filtered in different ways. For some complex views, I've found these kinds of specs can make understanding the expected results of a view easier to understand.