### PR TITLE
Bug fix for non-array keys and group_level option

### DIFF
--- a/lib/couch_potato/rspec/matchers/map_reduce_to_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/map_reduce_to_matcher.rb
@@ -140,7 +140,7 @@ module CouchPotato
 
             for (var mr in mapResults) {
               var mapResult = mapResults[mr];
-              var groupedKey = mapResult.key.slice(0, groupLevel);
+              var groupedKey = Array.isArray(mapResult.key) ? mapResult.key.slice(0, groupLevel) : mapResult.key;
               var groupFound = false;
               for (var g in grouped) {
                 var group = grouped[g];

--- a/spec/unit/rspec_matchers_spec.rb
+++ b/spec/unit/rspec_matchers_spec.rb
@@ -195,6 +195,21 @@ describe CouchPotato::RSpec::MapReduceToMatcher do
         {"key" => [26], "value" => 6},
         {"key" => [27], "value" => 8})
     end
+
+    it "should leave non-array keys intact when the :group_level option is specified" do
+      @view_spec = double(
+        :map_function => "function(doc) {
+          for (var i in doc.numbers)
+            emit(doc.age, doc.numbers[i]);
+          }",
+        :reduce_function => "function (keys, values, rereduce) {
+            return Math.max.apply(this, values);
+          }")
+      expect(@view_spec).to map_reduce(@docs).with_options(:group_level => 1).to(
+        {"key" => 25, "value" => 4},
+        {"key" => 26, "value" => 6},
+        {"key" => 27, "value" => 8})
+    end
   end
 
   describe "rereducing" do


### PR DESCRIPTION
If map/reduce view specs are used on a view with non-array keys (or a mix of array and non-array keys), and the `group_level` option is specified, it could result in either a Javascript error or incorrect keys in the view results. This pull request changes the `MapReduceToMatcher` to match couchdb's behavior in this scenario, which is to leave non-array keys intact when `group_level` is specified.