### PR TITLE
adds support for additional databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Another switch allows you to store each CouchDB view in its own design document.
 CouchPotato::Config.split_design_documents_per_view = true
 ```
 
+If you are using more than one datavase from your app, you can create aliases:
+
+```ruby
+CouchPotato::Config.additional_databases = {'db1' => 'db1_production', 'db2' => 'https://db2.example.com/db'}
+db1 = CouchPotato.use 'db1'
+```
+
 #### Using with Rails
 
 Create a `config/couchdb.yml`:
@@ -100,6 +107,9 @@ test:
 production:
   <<: *default
   database: <%= ENV['DB_NAME'] %>
+  additional_databases:
+    db1: db1_production
+    db2: https://db2.example.com/db
 ```
 
 #### Rails 3.x

--- a/lib/couch_potato.rb
+++ b/lib/couch_potato.rb
@@ -8,11 +8,12 @@ CouchRest.decode_json_objects = true
 
 module CouchPotato
   Config = Struct.new(:database_host, :database_name, :digest_view_names,
-    :split_design_documents_per_view, :default_language).new
+    :split_design_documents_per_view, :default_language, :additional_databases).new
   Config.split_design_documents_per_view = false
   Config.digest_view_names = false
   Config.default_language = :javascript
   Config.database_host = 'http://127.0.0.1:5984'
+  Config.additional_databases = {}
 
   class NotFound < StandardError; end
   class Conflict < StandardError; end
@@ -35,9 +36,10 @@ module CouchPotato
 
   # Returns a specific database instance
   def self.use(database_name)
+    resolved_database_name = Config.additional_databases[database_name] || database_name
     Thread.current[:__couch_potato_databases] ||= {}
-    Thread.current[:__couch_potato_databases][database_name] = Database.new(couchrest_database_for_name!(database_name)) unless Thread.current[:__couch_potato_databases][database_name]
-    Thread.current[:__couch_potato_databases][database_name]
+    Thread.current[:__couch_potato_databases][resolved_database_name] = Database.new(couchrest_database_for_name!(resolved_database_name)) unless Thread.current[:__couch_potato_databases][resolved_database_name]
+    Thread.current[:__couch_potato_databases][resolved_database_name]
   end
 
   # Executes a block of code and yields a datbase with the given name.
@@ -48,9 +50,7 @@ module CouchPotato
   #  end
   #
   def self.with_database(database_name)
-    Thread.current[:__couch_potato_databases] ||= {}
-    Thread.current[:__couch_potato_databases][database_name] = Database.new(couchrest_database_for_name(database_name)) unless Thread.current[:__couch_potato_databases][database_name]
-    yield Thread.current[:__couch_potato_databases][database_name]
+    yield use(database_name)
   end
 
   # Returns a CouchRest-Database for directly accessing that functionality.

--- a/lib/couch_potato/railtie.rb
+++ b/lib/couch_potato/railtie.rb
@@ -11,6 +11,7 @@ module CouchPotato
         CouchPotato::Config.database_name = config
       else
         CouchPotato::Config.database_name = config['database']
+        CouchPotato::Config.additional_databases = config['additional_databases'] if config['additional_databases']
         CouchPotato::Config.split_design_documents_per_view = config['split_design_documents_per_view'] if config['split_design_documents_per_view']
         CouchPotato::Config.digest_view_names = config['digest_view_names'] if config['digest_view_names']
         CouchPotato::Config.default_language = config['default_language'] if config['default_language']

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -83,6 +83,16 @@ describe "railtie" do
     end
   end
 
+  context 'yaml file contains additional_databases' do
+    it 'assigns additional_databases to config' do
+      allow(File).to receive_messages(:read => "test:\n  database: test\n  additional_databases:\n    db2: test2")
+
+      expect(CouchPotato::Config).to receive(:additional_databases=).with('db2' => 'test2')
+
+      CouchPotato.rails_init
+    end
+  end
+
   it "should process the yml file with erb" do
     allow(File).to receive_messages(:read => "test: \n  database: <%= 'db' %>")
 

--- a/spec/unit/couch_potato_spec.rb
+++ b/spec/unit/couch_potato_spec.rb
@@ -24,6 +24,15 @@ describe CouchPotato, 'use' do
     db = CouchPotato.use("testdb")
     expect(db.couchrest_database.root.to_s).to eq('http://127.0.0.1:5984/testdb')
   end
+
+  it 'returns a db from the additional_databases pool' do
+    CouchPotato::Config.database_host = 'http://127.0.0.1:5984'
+    CouchPotato::Config.additional_databases = {'1' => 'db1', '2' => 'db2'}
+
+    db = CouchPotato.use('2')
+
+    expect(db.couchrest_database.root.to_s).to eq('http://127.0.0.1:5984/db2')
+  end
 end
 
 describe CouchPotato, '.models' do


### PR DESCRIPTION
setting CouchPotato::Config.additional_databases to a hash of aliases - db names/urls allows you to access the databases by their alias via CouchPotato.use('alias')