### PR TITLE
Add default header to couch request

### DIFF
--- a/lib/couch_potato.rb
+++ b/lib/couch_potato.rb
@@ -5,6 +5,7 @@ require 'ostruct'
 
 JSON.create_id = 'ruby_class'
 CouchRest.decode_json_objects = true
+CouchRest::Connection::DEFAULT_HEADERS.merge!('Prefer' => 'return=minimal')
 
 module CouchPotato
   Config = Struct.new(:database_host, :database_name, :split_design_documents_per_view, :default_language).new


### PR DESCRIPTION
to minimise response headers for non browser clients. See https://github.com/apache/couchdb/pull/605

Seems the previous PR  was lost on clean up https://github.com/langalex/couch_potato/pull/129