### PR TITLE
support view option to disable sorting for faster responses

### DIFF
--- a/lib/couch_potato/view/base_view_spec.rb
+++ b/lib/couch_potato/view/base_view_spec.rb
@@ -81,9 +81,9 @@ module CouchPotato
       end
 
       def assert_sorted_false_not_with_startkey_endkey(params)
-        used_limit_params = (params.keys & [:startkey, :endkey, :startkey_docid, :endkey_docid])
-        if params[:sorted] == false && used_limit_params.any?
-          fail ArgumentError, "view parameter: `sorted: false` can not be combined with #{used_limit_params.join(', ')}"
+        used_key_params = params.keys & [:startkey, :endkey, :startkey_docid, :endkey_docid]
+        if params[:sorted] == false && used_key_params.any?
+          fail ArgumentError, "view parameter: `sorted: false` can not be combined with #{used_key_params.join(', ')}"
         end
       end
 

--- a/lib/couch_potato/view/base_view_spec.rb
+++ b/lib/couch_potato/view/base_view_spec.rb
@@ -13,6 +13,7 @@ module CouchPotato
         @language = options[:language] || Config.default_language
 
         assert_valid_view_parameters normalized_view_parameters
+        assert_sorted_false_not_with_startkey_endkey normalized_view_parameters
         @klass = klass
         @options = options
         @view_name = compute_view_name(view_name,
@@ -79,8 +80,15 @@ module CouchPotato
         end
       end
 
+      def assert_sorted_false_not_with_startkey_endkey(params)
+        used_limit_params = (params.keys & [:startkey, :endkey, :startkey_docid, :endkey_docid])
+        if params[:sorted] == false && used_limit_params.any?
+          fail ArgumentError, "view parameter: `sorted: false` can not be combined with #{used_limit_params.join(', ')}"
+        end
+      end
+
       def valid_view_parameters
-        %w(list_params key keys startkey startkey_docid endkey endkey_docid limit stale descending skip group group_level reduce include_docs inclusive_end)
+        %w(list_params key keys startkey startkey_docid endkey endkey_docid limit stale descending skip group group_level reduce include_docs inclusive_end sorted)
       end
 
       def translate_to_design_doc_name(klass_name, view_name, list_name)

--- a/spec/unit/base_view_spec_spec.rb
+++ b/spec/unit/base_view_spec_spec.rb
@@ -34,9 +34,20 @@ describe CouchPotato::View::BaseViewSpec, 'initialize' do
           :reduce => false,
           :include_docs => true,
           :inclusive_end => true,
-          :list_params => {}
+          :list_params => {},
+          :sorted => true,
         }
       }.not_to raise_error
+    end
+
+    it "raises an error when sorted false is combined with key limits" do
+      expect {
+        CouchPotato::View::BaseViewSpec.new Object, 'all', {}, {
+          :startkey => nil,
+          :endkey => {},
+          :sorted => false,
+        }
+      }.to raise_error(ArgumentError, "view parameter: `sorted: false` can not be combined with startkey, endkey")
     end
 
     it "removes stale when it's nil" do


### PR DESCRIPTION
(support from couchdb 2.0)
see: https://docs.couchdb.org/en/stable/api/ddoc/views.html#db-design-design-doc-view-view-name