### PR TITLE
add database.all

### DIFF
--- a/lib/couch_potato/database.rb
+++ b/lib/couch_potato/database.rb
@@ -97,9 +97,15 @@ module CouchPotato
       view(spec).first
     end
 
-    # returns th first result from a #view or raises CouchPotato::NotFound
+    # returns the first result from a #view or raises CouchPotato::NotFound
     def first!(spec)
       first(spec) || raise(CouchPotato::NotFound)
+    end
+
+    # returns all instances for a model
+    def all(model)
+      spec = CouchPotato::View::ModelViewSpec.new(model, 'all_model_instances', {}, {})
+      view(spec)
     end
 
     # saves a document. returns true on success, false on failure.

--- a/lib/couch_potato/view/view_query.rb
+++ b/lib/couch_potato/view/view_query.rb
@@ -17,7 +17,7 @@ module CouchPotato
       end
 
       def query_view!(parameters = {})
-        update_view unless view_has_been_updated?
+        update_view unless view_has_been_updated? || @view_name == 'all_model_instances' # all_model_instances is not for use in production code and should thus not be saved.
         begin
           query_view parameters
         rescue CouchRest::NotFound

--- a/spec/unit/database_spec.rb
+++ b/spec/unit/database_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'fixtures/address'
 
 class DbTestUser
   include CouchPotato::Persistence

--- a/spec/unit/database_spec.rb
+++ b/spec/unit/database_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'fixtures/address'
 
 class DbTestUser
   include CouchPotato::Persistence


### PR DESCRIPTION
Adds a database.all method that makes it possible to find e.g. all Invoices by saying db.all(Invoice).
To be used for debugging / finding records in one-off ways that don't warrant building a new view.

## Note

the failing specs (for jruby, active_support_6_0) didn't start failing in this commit but earlier, in commit a185a8092595b40ff6c68863b813e51d56a17961