### PR TITLE
Add database_collection to models

### DIFF
--- a/lib/couch_potato/database.rb
+++ b/lib/couch_potato/database.rb
@@ -224,6 +224,7 @@ module CouchPotato
       elsif processed_results.respond_to?(:each)
         processed_results.each do |document|
           document.database = self if document.respond_to?(:database=)
+          document.database_collection = processed_results if document.respond_to?(:database_collection=)
         end
       end
       processed_results
@@ -297,6 +298,7 @@ module CouchPotato
       docs = response['rows'].map { |row| row['doc'] }.compact
       docs.each do |doc|
         doc.database = self if doc.respond_to?(:database=)
+        doc.database_collection = docs if doc.respond_to?(:database_collection=)
       end
     end
 

--- a/lib/couch_potato/persistence.rb
+++ b/lib/couch_potato/persistence.rb
@@ -27,7 +27,7 @@ module CouchPotato
         ForbiddenAttributesProtection, Revisions
       base.send :include, Validation
       base.class_eval do
-        attr_accessor :_id, :_rev, :_deleted, :database
+        attr_accessor :_id, :_rev, :_deleted, :database, :database_collection
         alias_method :id, :_id
         alias_method :id=, :_id=
 

--- a/lib/couch_potato/view/flex_view_spec.rb
+++ b/lib/couch_potato/view/flex_view_spec.rb
@@ -73,9 +73,11 @@ module CouchPotato
         end
 
         def docs
+          all_docs = rows.map { |r| r['doc'] }
           rows.map do |row|
             doc = row['doc']
             doc.database = database if doc.respond_to?(:database=)
+            doc.database_collection = all_docs if doc.respond_to?(:database_collection=)
             doc
           end
         end

--- a/spec/unit/flex_view_spec_spec.rb
+++ b/spec/unit/flex_view_spec_spec.rb
@@ -15,3 +15,30 @@ RSpec.describe CouchPotato::View::FlexViewSpec::Results, '#reduce_count' do
     expect(result.reduce_count).to eq(0)
   end
 end
+
+RSpec.describe CouchPotato::View::FlexViewSpec::Results, '#docs' do
+  it 'sets the database on each doc' do
+    db = double('db')
+    doc = double('doc', 'database=': nil)
+
+    result = CouchPotato::View::FlexViewSpec::Results.new 'rows' => [{ 'doc' => doc }]
+    result.database = db
+
+    result.docs
+
+    expect(doc).to have_received(:database=).with(db)
+  end
+
+  it 'sets all docs as database_collection on each doc' do
+    doc = double('doc', 'database_collection=': nil)
+
+    result = CouchPotato::View::FlexViewSpec::Results.new 'rows' => [{ 'doc' => doc }]
+
+    result.docs
+
+    expect(doc).to have_received(:database_collection=).with([doc])
+  end
+
+  it 'returns the docs' do
+  end
+end


### PR DESCRIPTION
This allows code using this library to detect and avoid n+1 requests when loading associated models:

If database_collection is set on a model, instead of loading just one associated model by its id, code should load all associated models for all models in database_collection.