### PR TITLE
add digest to single design doc name

### DIFF
--- a/lib/couch_potato/view/view_query.rb
+++ b/lib/couch_potato/view/view_query.rb
@@ -41,6 +41,9 @@ module CouchPotato
         design_doc ||= empty_design_document
         if CouchPotato::Config.single_design_document
           design_doc['views'] = all_views
+          if CouchPotato::Config.digest_view_names
+            design_doc['_id'] = "_design/#{@design_document_name}-#{Digest::SHA256.hexdigest(design_doc['views'].to_json)}"
+          end
         else
           design_doc['views'][@view_name.to_s] = view_functions
         end

--- a/spec/unit/view_query_spec.rb
+++ b/spec/unit/view_query_spec.rb
@@ -8,6 +8,11 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
     CouchPotato::View::ViewQuery.clear_cache
   end
 
+  after(:each) do
+    CouchPotato::Config.single_design_document = false
+    CouchPotato::Config.digest_view_names = false
+  end
+
   it 'does not pass a key if conditions are empty' do
     expect(db).to receive(:view).with(anything, {})
     CouchPotato::View::ViewQuery.new(db, '', {:view0 => {}}).query_view!
@@ -80,5 +85,24 @@ describe CouchPotato::View::ViewQuery, 'query_view!' do
     allow(db).to receive(:get).and_return({'views' => {'view8' => {'map' => '<map_code>', 'reduce' => '<reduce_code>'}}})
     expect(db).to receive(:save_doc)
     CouchPotato::View::ViewQuery.new(db, 'design', :view8 => {:map => '<map_code>', :reduce => '<new reduce_code>'}).query_view!
+  end
+
+  it 'adds a digest of all views to the design document if single_design_doc is true' do
+    CouchPotato::Config.single_design_document = true
+    CouchPotato::Config.digest_view_names = true
+
+    allow(db).to receive(:get).and_return(nil)
+    allow(db).to receive(:save_doc).and_return(true)
+    view_class = double('view_class',
+      views: {view: {map: '<map_code>'}},
+      execute_view: double('view_spec', view_name: 'view', map_function: '<map_code>', reduce_function: nil))
+    allow(CouchPotato).to receive(:views).and_return([view_class])
+
+    CouchPotato::View::ViewQuery.new(
+      db, 
+      'couch_potato',
+      {:view => {:map => '<map_code>'}}).query_view!
+
+    expect(db).to have_received(:save_doc).with(hash_including({"_id" => "_design/couch_potato-56d286b4f0cd3a50fdd2ad428034d08a6483311539f7e138c45e781611b9dbbc"}))
   end
 end


### PR DESCRIPTION
this way, instead of updating the existing one (and blocking all view queries during that time) during a deployment, a new design doc is created when any views are changed.